### PR TITLE
Added a few things to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,16 @@ Due to corebird opening a browser whenever a link is clicked, as well as when se
 
 [Get Flatpak using these instructions](http://flatpak.org/getting.html)
 
-First, get the GNOME Runtime, if you don't have it:
+First, add the remote for the GNOME Runtime, if you don't have it:
 ```shell
 flatpak remote-add --from gnome https://sdk.gnome.org/gnome.flatpakrepo
-flatpak install gnome org.gnome.Platform 3.22
 ```
 
 Then, create the repository:
-
 ```shell
 flatpak --user remote-add -from=baedert.flatpakrepo
 ```
+
 or manually:
 ```shell
 wget https://baedert.org/repo/baedert-repo.gpg

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@ This is a `flatpak-builder` definition file to build both corebird master and cu
 
 Due to corebird opening a browser whenever a link is clicked, as well as when setting up an account, you need to have `xdg-desktop-portal` as well as one implementation for it (currently there is only `xdg-desktop-portal-gtk` as far as I know) installed.
 
-First, create the repository:
+[Getting Flatpak](http://flatpak.org/getting.html)
+
+First, get the GNOME Runtime, if you don't have it
+```shell
+flatpak remote-add --from gnome https://sdk.gnome.org/gnome.flatpakrepo
+flatpak install gnome org.gnome.Platform 3.22
+```
+
+Then, create the repository:
 
 ```shell
 flatpak --user remote-add -from=baedert.flatpakrepo

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is a `flatpak-builder` definition file to build both corebird master and cu
 
 Due to corebird opening a browser whenever a link is clicked, as well as when setting up an account, you need to have `xdg-desktop-portal` as well as one implementation for it (currently there is only `xdg-desktop-portal-gtk` as far as I know) installed.
 
-[Getting Flatpak](http://flatpak.org/getting.html)
+[Get Flatpak using these instructions](http://flatpak.org/getting.html)
 
-First, get the GNOME Runtime, if you don't have it
+First, get the GNOME Runtime, if you don't have it:
 ```shell
 flatpak remote-add --from gnome https://sdk.gnome.org/gnome.flatpakrepo
 flatpak install gnome org.gnome.Platform 3.22


### PR DESCRIPTION
Check the commit notes for details. You might not want to do things this way but this is how I would do it :)

Although this makes the install instructions longer, it means anyone can install the Flatpak from the instructions, even those who don't have Flatpak or the GNOME Runtime yet.